### PR TITLE
Add LDAP log analysis command with interactive and comparison modes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 .aider*
 .env
 .ai
+debugger.ts

--- a/Contribution.md
+++ b/Contribution.md
@@ -79,20 +79,20 @@ This will start the UI in development mode, typically on port 3000.
 #### Running the CLI during development:
 
 ```bash
-bun run ./cmd/src/main.ts --help
+./analog --help
 ```
 
 For specific CLI commands:
 
 ```bash
 # Summary command
-bun run ./cmd/src/main.ts --summary --help
+./analog --summary --help
 
 # Filter command
-bun run ./cmd/src/main.ts --filter --help
+./analog --filter --help
 
 # Web command
-bun run ./cmd/src/main.ts --web --help
+./analog --web --help
 ```
 
 ### Build Process

--- a/Contribution.md
+++ b/Contribution.md
@@ -79,20 +79,14 @@ This will start the UI in development mode, typically on port 3000.
 #### Running the CLI during development:
 
 ```bash
-./analog --help
+bun run ./cmd/src/main.ts --help
 ```
 
 For specific CLI commands:
 
 ```bash
 # Summary command
-./analog --summary --help
-
-# Filter command
-./analog --filter --help
-
-# Web command
-./analog --web --help
+bun run ./cmd/src/main.ts --summary --help
 ```
 
 ### Build Process
@@ -126,20 +120,19 @@ Once you've built the application and generated binaries, you can run them direc
 #### Running the Web UI with the binary:
 
 ```bash
-./analog web
+./analog --web
 ```
 
 With custom port:
 
 ```bash
-./analog web --port 8080
+./analog --web --port 8080
 ```
 
 #### Running the CLI with the binary:
 
 ```bash
-./analog summary --help
-./analog filter --help
+./analog --summary --help
 ```
 
 ## Feedback and Assistance

--- a/cmd/bun.lock
+++ b/cmd/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "analog",
       "dependencies": {
+        "@inquirer/prompts": "^7.4.1",
         "console-table-printer": "^2.12.0",
         "figlet": "^1.7.0",
         "pretty-bytes": "^6.1.1",
@@ -17,25 +18,95 @@
     },
   },
   "packages": {
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.1.5", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.9", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w=="],
+
+    "@inquirer/core": ["@inquirer/core@10.1.10", "", { "dependencies": { "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "^2.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw=="],
+
+    "@inquirer/editor": ["@inquirer/editor@4.2.10", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "external-editor": "^3.1.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw=="],
+
+    "@inquirer/expand": ["@inquirer/expand@4.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.11", "", {}, "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw=="],
+
+    "@inquirer/input": ["@inquirer/input@4.1.9", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA=="],
+
+    "@inquirer/number": ["@inquirer/number@3.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q=="],
+
+    "@inquirer/password": ["@inquirer/password@4.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@7.4.1", "", { "dependencies": { "@inquirer/checkbox": "^4.1.5", "@inquirer/confirm": "^5.1.9", "@inquirer/editor": "^4.2.10", "@inquirer/expand": "^4.0.12", "@inquirer/input": "^4.1.9", "@inquirer/number": "^3.0.12", "@inquirer/password": "^4.0.12", "@inquirer/rawlist": "^4.0.12", "@inquirer/search": "^3.0.12", "@inquirer/select": "^4.1.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA=="],
+
+    "@inquirer/search": ["@inquirer/search@3.0.12", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ=="],
+
+    "@inquirer/select": ["@inquirer/select@4.1.1", "", { "dependencies": { "@inquirer/core": "^10.1.10", "@inquirer/figures": "^1.0.11", "@inquirer/type": "^3.0.6", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.6", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA=="],
+
     "@types/bun": ["@types/bun@1.0.4", "", { "dependencies": { "bun-types": "1.0.25" } }, "sha512-2DO7sqwtpko3d3XP2kLpJsOkV12sSRt8cFR955JVB60m1DiXE56T+gJq+DcCczQ5khxgCDQKkyBRlgg5VH33Dw=="],
 
     "@types/node": ["@types/node@20.11.10", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-rZEfe/hJSGYmdfX9tvcPMYeYPW2sNl50nsw4jZmRcaG0HIAb0WYEpsB05GOb53vjqpyE9GUhlDQ4jLSoB5q9kg=="],
 
     "@types/ws": ["@types/ws@8.5.10", "", { "dependencies": { "@types/node": "*" } }, "sha512-vmQSUcfalpIq0R9q7uTo2lXs6eGIpt9wtnLdMv9LVpIjCA/+ufZRozlVoVelIYixx1ugCBKDhn89vnsEGOCx9A=="],
 
+    "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
+
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
     "bun-types": ["bun-types@1.0.25", "", { "dependencies": { "@types/node": "*", "@types/ws": "*", "undici-types": "^5.26.4" } }, "sha512-9lxeUR/OJsvlZH4GOWteiAdx7ikrSxCUX7Rr0JJux+DrR3LejouVLxIZnTeQ3UPAZovvSgKivWeHPJ2wlo7/Kg=="],
+
+    "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
     "console-table-printer": ["console-table-printer@2.12.0", "", { "dependencies": { "simple-wcswidth": "^1.0.1" } }, "sha512-Q/Ax+UOpZw0oPZGmv8bH8/W5NpC2rAYy6cX20BVLGQ45v944oL+srmLTZAse/5a3vWDl0MXR/0GTEdsz2dDTbg=="],
 
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
+
     "figlet": ["figlet@1.7.0", "", { "bin": { "figlet": "bin/index.js" } }, "sha512-gO8l3wvqo0V7wEFLXPbkX83b7MVjRrk1oRLfYlZXol8nEpb/ON9pcKLI4qpBv5YtOTfrINtqb7b40iYY2FTWFg=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "mute-stream": ["mute-stream@2.0.0", "", {}, "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA=="],
+
+    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "simple-wcswidth": ["simple-wcswidth@1.0.1", "", {}, "sha512-xMO/8eNREtaROt7tJvWJqHBDTMFN4eiQ5I4JRMuilwfnFcV5W9u7RUkueNkdw0jPqGMX36iCywelS5yilTuOxg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+
+    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "typescript": ["typescript@5.3.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw=="],
 
     "undici-types": ["undici-types@5.28.2", "", {}, "sha512-W71OLwDqzIO0d3k07qg1xc7d4cX8SsSwuCO4bQ4V7ITwduXXie/lcImofabP5VV+NvuvSe8ovKvHVJcizVc1JA=="],
+
+    "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.2", "", {}, "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA=="],
 
     "@types/node/undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
   }

--- a/cmd/package.json
+++ b/cmd/package.json
@@ -12,6 +12,7 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
+    "@inquirer/prompts": "^7.4.1",
     "console-table-printer": "^2.12.0",
     "figlet": "^1.7.0",
     "pretty-bytes": "^6.1.1"

--- a/cmd/src/commands/ldap/compare.ts
+++ b/cmd/src/commands/ldap/compare.ts
@@ -1,0 +1,221 @@
+import type { Flags } from "./types";
+import {
+  parseLogs as parseGroupLogs,
+  type PathsResult,
+  createPathsToUser,
+} from "./group-paths";
+import { parseLogs as parseUserLogs, type SearchResult } from "./search-user";
+import { getSortedLines } from "./helper";
+
+interface ComparisonResult {
+  userAttributeDiffs: {
+    job1: Record<string, string>;
+    job2: Record<string, string>;
+  };
+  pathDiffs: {
+    onlyInJob1: string[][];
+    onlyInJob2: string[][];
+  };
+  groupDiffs: {
+    onlyInJob1: Set<string>;
+    onlyInJob2: Set<string>;
+  };
+}
+
+function compareAttributes(
+  result1: SearchResult | null,
+  result2: SearchResult | null
+): ComparisonResult["userAttributeDiffs"] {
+  const diffs = {
+    job1: {} as Record<string, string>,
+    job2: {} as Record<string, string>,
+  };
+
+  // If either result is null, treat all attributes from the other as different
+  if (!result1 || !result2) {
+    if (result1) {
+      diffs.job1 = { ...result1.attributes };
+    }
+    if (result2) {
+      diffs.job2 = { ...result2.attributes };
+    }
+    return diffs;
+  }
+
+  // Compare attributes and collect differences
+  const allKeys = new Set([
+    ...Object.keys(result1.attributes),
+    ...Object.keys(result2.attributes),
+  ]);
+
+  for (const key of allKeys) {
+    const val1 = result1.attributes[key];
+    const val2 = result2.attributes[key];
+
+    if (val1 !== val2) {
+      if (val1 !== undefined) diffs.job1[key] = val1;
+      if (val2 !== undefined) diffs.job2[key] = val2;
+    }
+  }
+
+  return diffs;
+}
+
+function comparePaths(
+  paths1: PathsResult,
+  paths2: PathsResult
+): Pick<ComparisonResult, "pathDiffs" | "groupDiffs"> {
+  const pathDiffs = {
+    onlyInJob1: [] as string[][],
+    onlyInJob2: [] as string[][],
+  };
+
+  const groupDiffs = {
+    onlyInJob1: new Set<string>(),
+    onlyInJob2: new Set<string>(),
+  };
+
+  // Convert paths to strings for easier comparison
+  const pathStrings1 = new Set(paths1.paths.map((p) => p.join(" -> ")));
+  const pathStrings2 = new Set(paths2.paths.map((p) => p.join(" -> ")));
+
+  // Find paths unique to job1
+  for (const path of paths1.paths) {
+    const pathStr = path.join(" -> ");
+    if (!pathStrings2.has(pathStr)) {
+      pathDiffs.onlyInJob1.push(path);
+    }
+  }
+
+  // Find paths unique to job2
+  for (const path of paths2.paths) {
+    const pathStr = path.join(" -> ");
+    if (!pathStrings1.has(pathStr)) {
+      pathDiffs.onlyInJob2.push(path);
+    }
+  }
+
+  // Find groups unique to each job
+  for (const group of paths1.groupsLeadingToUser) {
+    if (!paths2.groupsLeadingToUser.has(group)) {
+      groupDiffs.onlyInJob1.add(group);
+    }
+  }
+
+  for (const group of paths2.groupsLeadingToUser) {
+    if (!paths1.groupsLeadingToUser.has(group)) {
+      groupDiffs.onlyInJob2.add(group);
+    }
+  }
+
+  return { pathDiffs, groupDiffs };
+}
+
+function printComparisonResults(
+  jobId1: string,
+  jobId2: string,
+  results: ComparisonResult
+): void {
+  console.log("\n========= User Attribute Differences =========");
+  if (
+    Object.keys(results.userAttributeDiffs.job1).length === 0 &&
+    Object.keys(results.userAttributeDiffs.job2).length === 0
+  ) {
+    console.log("No differences in user attributes found.");
+  } else {
+    console.log(`\nAttributes in job ${jobId1} that differ:`);
+    for (const [key, value] of Object.entries(
+      results.userAttributeDiffs.job1
+    )) {
+      console.log(`  ${key}: ${value}`);
+    }
+
+    console.log(`\nAttributes in job ${jobId2} that differ:`);
+    for (const [key, value] of Object.entries(
+      results.userAttributeDiffs.job2
+    )) {
+      console.log(`  ${key}: ${value}`);
+    }
+  }
+
+  console.log("\n========= Path Differences =========");
+  if (
+    results.pathDiffs.onlyInJob1.length === 0 &&
+    results.pathDiffs.onlyInJob2.length === 0
+  ) {
+    console.log("No differences in paths found.");
+  } else {
+    if (results.pathDiffs.onlyInJob1.length > 0) {
+      console.log(`\nPaths only in job ${jobId1}:`);
+      results.pathDiffs.onlyInJob1
+        .map((path) => path.join(" -> "))
+        .sort()
+        .forEach((path) => console.log(`  ${path}`));
+    }
+
+    if (results.pathDiffs.onlyInJob2.length > 0) {
+      console.log(`\nPaths only in job ${jobId2}:`);
+      results.pathDiffs.onlyInJob2
+        .map((path) => path.join(" -> "))
+        .sort()
+        .forEach((path) => console.log(`  ${path}`));
+    }
+  }
+
+  console.log("\n========= Group Differences =========");
+  if (
+    results.groupDiffs.onlyInJob1.size === 0 &&
+    results.groupDiffs.onlyInJob2.size === 0
+  ) {
+    console.log("No differences in groups found.");
+  } else {
+    if (results.groupDiffs.onlyInJob1.size > 0) {
+      console.log(`\nGroups only in job ${jobId1}:`);
+      console.log([...results.groupDiffs.onlyInJob1].sort().join(", "));
+    }
+
+    if (results.groupDiffs.onlyInJob2.size > 0) {
+      console.log(`\nGroups only in job ${jobId2}:`);
+      console.log([...results.groupDiffs.onlyInJob2].sort().join(", "));
+    }
+  }
+}
+
+async function handleComparison(
+  flags: Flags & { compareJobId: string }
+): Promise<void> {
+  console.log("\n========= Comparing LDAP Data =========");
+  const fileLines = await getSortedLines(flags);
+
+  // Get user attributes for both jobs
+  console.log("\nFetching user attributes...");
+  const userResult1 = parseUserLogs(
+    { ...flags, jobId: flags.jobId },
+    fileLines
+  );
+  const userResult2 = parseUserLogs(
+    { ...flags, jobId: flags.compareJobId },
+    fileLines
+  );
+
+  // Get group paths for both jobs
+  console.log("\nAnalyzing group paths...");
+  const groupResult1 = parseGroupLogs(fileLines, flags.jobId);
+  const groupResult2 = parseGroupLogs(fileLines, flags.compareJobId);
+
+  const pathResults1 = createPathsToUser(groupResult1, flags.userCN);
+  const pathResults2 = createPathsToUser(groupResult2, flags.userCN);
+
+  // Compare results
+  const attrDiffs = compareAttributes(userResult1, userResult2);
+  const { pathDiffs, groupDiffs } = comparePaths(pathResults1, pathResults2);
+
+  // Print results
+  printComparisonResults(flags.jobId, flags.compareJobId, {
+    userAttributeDiffs: attrDiffs,
+    pathDiffs,
+    groupDiffs,
+  });
+}
+
+export default handleComparison;

--- a/cmd/src/commands/ldap/compare.ts
+++ b/cmd/src/commands/ldap/compare.ts
@@ -181,9 +181,7 @@ function printComparisonResults(
   }
 }
 
-async function handleComparison(
-  flags: Flags & { compareJobId: string }
-): Promise<void> {
+async function handleComparison(flags: Flags): Promise<void> {
   console.log("\n========= Comparing LDAP Data =========");
   const fileLines = await getSortedLines(flags);
 

--- a/cmd/src/commands/ldap/group-paths.ts
+++ b/cmd/src/commands/ldap/group-paths.ts
@@ -1,4 +1,4 @@
-import { getSortedLines } from "./helper";
+import { getSortedLines, regexes } from "./helper";
 import type { FileLines, Flags } from "./types";
 
 interface PathsResult {
@@ -8,11 +8,6 @@ interface PathsResult {
 }
 
 type GroupMap = Map<string, Set<string>>;
-
-const patterns = {
-  cn: /CN=([^,]+)/,
-  member: /member/,
-};
 
 async function handleGroupPaths(flags: Flags): Promise<void> {
   console.log("\n========= Parsing Logs =========");
@@ -138,7 +133,7 @@ function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
 
     // Look for Object Name line to get the group CN
     if (line.startsWith("Object Name:")) {
-      const cnMatch = line.match(patterns.cn);
+      const cnMatch = line.match(regexes.cn);
       if (cnMatch && cnMatch[1]) {
         currentGroupCN = cnMatch[1];
         if (!groupUserCNs.has(currentGroupCN)) {
@@ -151,7 +146,7 @@ function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
     }
 
     // Look for the member attribute within the current group context
-    if (line.startsWith("Attribute Name:") && line.match(patterns.member)) {
+    if (line.startsWith("Attribute Name:") && line.match(regexes.member)) {
       foundMemberAttribute = true;
       continue;
     }
@@ -163,7 +158,7 @@ function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
     }
 
     if (isProcessingMembers && line.startsWith("Attribute Value:")) {
-      const cnMatch = line.match(patterns.cn);
+      const cnMatch = line.match(regexes.cn);
       if (cnMatch && currentGroupCN) {
         const memberCN = cnMatch[1];
         groupUserCNs.get(currentGroupCN)?.add(memberCN);

--- a/cmd/src/commands/ldap/group-paths.ts
+++ b/cmd/src/commands/ldap/group-paths.ts
@@ -1,0 +1,190 @@
+import { getSortedLines } from "./helper";
+import type { FileLines, Flags } from "./types";
+
+interface PathsResult {
+  paths: string[][]; // All paths ending at the target user
+  cycleGroups: Set<string>; // Unique groups that are part of a cycle
+  groupsLeadingToUser: Set<string>; // Unique groups that eventually lead to the target user
+}
+
+type GroupMap = Map<string, Set<string>>;
+
+const patterns = {
+  cn: /CN=([^,]+)/,
+  member: /member/,
+};
+
+async function handleGroupPaths(flags: Flags): Promise<void> {
+  console.log("\n========= Parsing Logs =========");
+  const fileLines: FileLines[] = await getSortedLines(flags);
+  const groupUserCNs = parseLogs(fileLines, flags.jobId);
+  console.log("========= Finished Parsing Logs =========");
+
+  if (groupUserCNs.size === 0) {
+    console.log(
+      `No group information found for job ID "${flags.jobId}" in the processed files.`
+    );
+    return;
+  }
+
+  console.log(`\n========= Finding Paths for User: ${flags.userCN} =========`);
+  const pathsResults = createPathsToUser(groupUserCNs, flags.userCN);
+  console.log(`========= Finished Finding Paths =========`);
+
+  printResults(pathsResults, flags);
+}
+
+function printResults(pathsResults: PathsResult, flags: Flags) {
+  const { paths, cycleGroups, groupsLeadingToUser } = pathsResults;
+  if (paths.length === 0) {
+    console.log(
+      `User "${flags.userCN}" not found in any group memberships for job ID "${flags.jobId}" in the processed files.`
+    );
+    return;
+  }
+
+  const sortedPaths = paths
+    .map((path) => path.join(" -> "))
+    .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
+  console.log(`Found ${sortedPaths.length} paths to user ${flags.userCN}:`);
+  console.log(sortedPaths.join("\n"));
+
+  console.log("\n---");
+  console.log(`Found ${cycleGroups.size} cyclic groups involved in paths:`);
+  console.log(Array.from(cycleGroups).join(", "));
+
+  console.log("\n---");
+  console.log(
+    `Found ${groupsLeadingToUser.size} unique groups leading to user ${flags.userCN}:`
+  );
+  console.log(Array.from(groupsLeadingToUser).join(", "));
+}
+
+function createPathsToUser(
+  groupUserCNs: GroupMap,
+  userCN: string
+): PathsResult {
+  const paths: string[][] = [];
+  const cycleGroups = new Set<string>();
+  const groupsLeadingToUser = new Set<string>();
+
+  // Run iterative DFS starting from every group key.
+  for (const group of groupUserCNs.keys()) {
+    // Each stack entry stores the current group and the path taken so far.
+    const stack: { group: string; currentPath: string[] }[] = [
+      { group, currentPath: [group] },
+    ];
+
+    while (stack.length > 0) {
+      const { group: current, currentPath } = stack.pop()!;
+
+      const members = groupUserCNs.get(current);
+      if (!members) continue;
+
+      for (const member of members) {
+        // Check for cycles in the current path.
+        if (currentPath.includes(member)) {
+          cycleGroups.add(member);
+          continue;
+        }
+
+        // If we find the target user, record the valid path.
+        if (member === userCN) {
+          const validPath = [...currentPath, member];
+          paths.push(validPath);
+          // Mark all groups along this path as leading to the target.
+          for (const grp of currentPath) {
+            groupsLeadingToUser.add(grp);
+          }
+        }
+
+        // If the member is also a group, continue DFS.
+        if (groupUserCNs.has(member)) {
+          stack.push({ group: member, currentPath: [...currentPath, member] });
+        }
+      }
+    }
+  }
+
+  return { paths, cycleGroups, groupsLeadingToUser };
+}
+
+function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
+  const groupUserCNs: GroupMap = new Map<string, Set<string>>();
+  const responseIdentifier = `Got response worker_name=EnterpriseLdapSync job_id=${jobId}`;
+
+  let gotResponse = false;
+  let currentGroupCN: string | null = null;
+  let isProcessingMembers = false;
+  let foundMemberAttribute = false;
+
+  const lines = fileLines.flatMap((fileLine) => fileLine.lines);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // Look for the start of a new LDAP response for the specific job ID
+    if (line.includes(responseIdentifier)) {
+      gotResponse = true;
+      currentGroupCN = null;
+      isProcessingMembers = false;
+      foundMemberAttribute = false;
+      continue;
+    }
+
+    if (!gotResponse) continue;
+
+    // Look for Object Name line to get the group CN
+    if (line.startsWith("Object Name:")) {
+      const cnMatch = line.match(patterns.cn);
+      if (cnMatch && cnMatch[1]) {
+        currentGroupCN = cnMatch[1];
+        if (!groupUserCNs.has(currentGroupCN)) {
+          groupUserCNs.set(currentGroupCN, new Set());
+        }
+        isProcessingMembers = false; // Reset processing state for the new object
+        foundMemberAttribute = false;
+      }
+      continue;
+    }
+
+    // Look for the member attribute within the current group context
+    if (line.startsWith("Attribute Name:") && line.match(patterns.member)) {
+      foundMemberAttribute = true;
+      continue;
+    }
+
+    // Process member values if the member attribute was found
+    if (foundMemberAttribute && line.startsWith("Attribute Values:")) {
+      isProcessingMembers = true;
+      continue;
+    }
+
+    if (isProcessingMembers && line.startsWith("Attribute Value:")) {
+      const cnMatch = line.match(patterns.cn);
+      if (cnMatch && currentGroupCN) {
+        const memberCN = cnMatch[1];
+        groupUserCNs.get(currentGroupCN)?.add(memberCN);
+      }
+      continue;
+    }
+
+    // If we are processing members but the line is not an Attribute Value,
+    // it means the member section ended. Reset flags.
+    // Also reset gotResponse as we might encounter logs for other jobs.
+    if (isProcessingMembers && !line.startsWith("Attribute Value:")) {
+      isProcessingMembers = false;
+      foundMemberAttribute = false;
+      gotResponse = false; // Reset to look for the next relevant response block
+    }
+  }
+
+  console.log(
+    `Successfully parsed ${groupUserCNs.size} groups from LDAP log for job ${jobId}`
+  );
+  return groupUserCNs;
+}
+
+export default handleGroupPaths;

--- a/cmd/src/commands/ldap/group-paths.ts
+++ b/cmd/src/commands/ldap/group-paths.ts
@@ -1,7 +1,7 @@
 import { getSortedLines, regexes } from "./helper";
 import type { FileLines, Flags } from "./types";
 
-interface PathsResult {
+export interface PathsResult {
   paths: string[][]; // All paths ending at the target user
   cycleGroups: Set<string>; // Unique groups that are part of a cycle
   groupsLeadingToUser: Set<string>; // Unique groups that eventually lead to the target user
@@ -56,7 +56,7 @@ function printResults(pathsResults: PathsResult, flags: Flags) {
   console.log(Array.from(groupsLeadingToUser).join(", "));
 }
 
-function createPathsToUser(
+export function createPathsToUser(
   groupUserCNs: GroupMap,
   userCN: string
 ): PathsResult {
@@ -105,7 +105,7 @@ function createPathsToUser(
   return { paths, cycleGroups, groupsLeadingToUser };
 }
 
-function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
+export function parseLogs(fileLines: FileLines[], jobId: string): GroupMap {
   const groupUserCNs: GroupMap = new Map<string, Set<string>>();
   const responseIdentifier = `Got response worker_name=EnterpriseLdapSync job_id=${jobId}`;
 

--- a/cmd/src/commands/ldap/helper.ts
+++ b/cmd/src/commands/ldap/helper.ts
@@ -20,21 +20,21 @@ function findFirstTimestamp(lines: string[]): string | null {
 }
 
 export async function getSortedLines(flags: Flags): Promise<FileLines[]> {
-  const filePaths = await fileHelper.getFilesRecursively(
-    flags.inFolderPath,
+  const filePaths = await fileHelper.getFiles(
+    flags.path,
     flags.prefix,
     flags.suffix
   );
 
   if (filePaths.length === 0) {
     console.log(
-      `No files found matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}". Exiting.`
+      `No files found matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.path}". Exiting.`
     );
     process.exit(0);
   }
 
   console.log(
-    `\nFound ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
+    `\nFound ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.path}"`
   );
 
   console.log("\n========= Reading Files & Finding Timestamps =========");

--- a/cmd/src/commands/ldap/helper.ts
+++ b/cmd/src/commands/ldap/helper.ts
@@ -1,13 +1,17 @@
 import fileHelper from "@al/cmd/utils/file-helper";
 import type { FileLines, Flags } from "./types";
 
+export const regexes = {
+  cn: /CN=([^,]+)/,
+  member: /member/,
+  lastDoubleQuote: /"([^"]+)"/,
+  // example log line with time: LDAPTrace [2025-03-15 06:40:06.319 +11:00] Got response
+  time: /\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} [+-]\d{2}:\d{2})\]/,
+};
+
 function findFirstTimestamp(lines: string[]): string | null {
-  // Regex to match "LDAPTrace [timestamp]" and capture the timestamp part
-  // Example: LDAPTrace [2025-03-15 07:28:00.045 +11:00] some message
-  const timestampRegex =
-    /^(?:LDAPTrace|LDAPDebug)\s+\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+[+-]\d{2}:\d{2})\]/;
   for (const line of lines) {
-    const match = line.match(timestampRegex);
+    const match = line.match(regexes.time);
     if (match && match[1]) {
       return match[1]; // Return the captured timestamp string
     }

--- a/cmd/src/commands/ldap/helper.ts
+++ b/cmd/src/commands/ldap/helper.ts
@@ -1,0 +1,83 @@
+import fileHelper from "@al/cmd/utils/file-helper";
+import type { FileLines, Flags } from "./types";
+
+function findFirstTimestamp(lines: string[]): string | null {
+  // Regex to match "LDAPTrace [timestamp]" and capture the timestamp part
+  // Example: LDAPTrace [2025-03-15 07:28:00.045 +11:00] some message
+  const timestampRegex =
+    /^(?:LDAPTrace|LDAPDebug)\s+\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+[+-]\d{2}:\d{2})\]/;
+  for (const line of lines) {
+    const match = line.match(timestampRegex);
+    if (match && match[1]) {
+      return match[1]; // Return the captured timestamp string
+    }
+  }
+  return null; // Return null if no matching line is found
+}
+
+export async function getSortedLines(flags: Flags): Promise<FileLines[]> {
+  const filePaths = await fileHelper.getFilesRecursively(
+    flags.inFolderPath,
+    flags.prefix,
+    flags.suffix
+  );
+
+  if (filePaths.length === 0) {
+    console.log(
+      `No files found matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}". Exiting.`
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `\nFound ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
+  );
+
+  console.log("\n========= Reading Files & Finding Timestamps =========");
+
+  const fileData: {
+    filePath: string;
+    lines: string[];
+    firstTimestamp: string | null;
+  }[] = [];
+  for (const filePath of filePaths) {
+    console.log(`Reading: ${filePath}`);
+    try {
+      const content = await Bun.file(filePath).text();
+      const lines = content.split(/\r?\n/); // Keep escaped regex
+      const firstTimestamp = findFirstTimestamp(lines);
+      if (firstTimestamp) {
+        fileData.push({ filePath, lines, firstTimestamp });
+        console.log(`  Found start timestamp: ${firstTimestamp}`);
+      } else {
+        console.log(
+          `  Warning: No 'LDAPTrace [timestamp]' line found in ${filePath}. Skipping file.`
+        );
+      }
+    } catch (err) {
+      console.error(`Error reading or processing file ${filePath}:`, err);
+    }
+  }
+
+  if (fileData.length === 0) {
+    console.log("No valid files with timestamps found to process. Exiting.");
+    process.exit(0);
+  }
+
+  console.log("========= Sorting Files by Timestamp =========");
+  fileData.sort((a, b) => a.firstTimestamp!.localeCompare(b.firstTimestamp!));
+
+  const sortedFileData: FileLines[] = [];
+  console.log("Sorted file order:");
+  fileData.forEach((f) => {
+    console.log(`  - ${f.filePath} (${f.firstTimestamp})`);
+    sortedFileData.push({
+      filePath: f.filePath,
+      lines: f.lines,
+    });
+  });
+
+  console.log("========= Finished Reading & Sorting Files =========");
+
+  return sortedFileData;
+}

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -9,19 +9,35 @@ const flags: Flags = { ...defaultFlags };
 
 function help(): void {
   console.log(`
-Parses LDAP log files to find all group membership paths for a specific user and job ID.
+Parses LDAP log files to find all group membership paths for a specific user and job ID, or search for users based on various criteria.
 
 Usage:
 
   ./analog --ldap [arguments]
 
-The arguments are:
+The command operates in two modes:
+
+1. Interactive Mode:
+   Run without "--jobId" and "--user" arguments to enter interactive mode:
+
+   This mode allows you to:
+   - Search for user attributes in login or job response blocks
+   - Filter by specific job ID
+   - Search by user CN or multiple attributes (email, name, etc.)
+   - Specify time ranges for the search
+
+2. Non-interactive Mode:
+   Run with "--jobId" and "--user" arguments to find group membership paths:
+
+The arguments for non-interactive mode only:
 
   -j, --jobId
         (Required) Specifies the job ID to filter the logs by.
 
   -u, --user        
         (Required) Specifies the user CN (Common Name) to find paths for.
+
+Common arguments for both modes:
 
   -i, --inFolderPath
         Specifies the path to the folder containing the LDAP log files.
@@ -36,9 +52,13 @@ The arguments are:
         Specifies the suffix for the log files to include.
         Default: log
 
-Example:
+Examples:
 
-  ./analog --ldap -j "wsqt9pbpa7yz8gdssw47xzn8hw" -u "John Doe" -i "/path/to/ldap/logs"
+  1. Interactive mode:
+     ./analog --ldap -i /path/to/ldap/logs
+
+  2. Non-interactive mode (find group paths):
+     ./analog --ldap -j wsqt9pbpa7yz8gdssw47xzn8hw -u "John Doe" -i /path/to/ldap/logs
   `);
 }
 

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -6,7 +6,7 @@ import handleUserSearch from "./search-user";
 import handleGroupPaths from "./group-paths";
 import handleComparison from "./compare";
 
-const flags: Flags & { compareJobId?: string } = { ...defaultFlags };
+const flags: Flags = { ...defaultFlags };
 
 function help(): void {
   console.log(`
@@ -141,14 +141,16 @@ function parseFlags(): boolean {
 async function run(): Promise<void> {
   const interactive = parseFlags();
   if (interactive) {
-    console.log("No flags provided, running in interactive mode...\n");
+    console.log(
+      "--user and --jobId not provided, running in interactive mode...\n"
+    );
     await handleUserSearch(flags);
     return;
   }
 
   // Check if comparison mode
   if (flags.compareJobId) {
-    await handleComparison({ ...flags, compareJobId: flags.compareJobId });
+    await handleComparison(flags);
     return;
   }
 

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -336,8 +336,11 @@ async function processLogs() {
       `User "${flags.userCN}" not found in any group memberships for job ID "${flags.jobId}" in the processed files.`
     );
   } else {
-    console.log(`Found ${paths.length} paths to user ${flags.userCN}:`);
-    console.log(paths.map((path) => path.join(" -> ")).join("\n"));
+    const sortedPaths = paths
+      .map((path) => path.join(" -> "))
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    console.log(`Found ${sortedPaths.length} paths to user ${flags.userCN}:`);
+    console.log(sortedPaths.join("\n"));
     console.log("\n---");
     console.log(`Found ${cycleGroups.size} cyclic groups involved in paths:`);
     console.log(Array.from(cycleGroups).join(", "));

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -47,9 +47,10 @@ The arguments for non-interactive and comparison modes:
 
 Common arguments for all modes:
 
-  -i, --inFolderPath
-        Specifies the path to the folder containing the LDAP log files.
-        The folder should only contain log files or nested folders with log files.
+  -p, --path
+        Specifies the path to either a single log file or a folder containing log files.
+        If a folder is provided, it traverses all the files in the folder and its subfolders.
+        If a file is provided, then prefix and suffix flags are ignored.
         Default: . (current directory)
 
   --prefix
@@ -63,13 +64,13 @@ Common arguments for all modes:
 Examples:
 
   1. Interactive mode:
-     ./analog --ldap -i /path/to/ldap/logs
+     ./analog --ldap -p /path/to/ldap/logs
 
-  2. Non-interactive mode (find group paths):
-     ./analog --ldap -j wsqt9pbpa7yz8gdssw47xzn8hw -u "John Doe" -i /path/to/ldap/logs
+  2. Non-interactive mode (find groups to user paths):
+     ./analog --ldap -j wsqt9pbpa7yz8gdssw47xzn8hw -u "John Doe" -p /path/to/ldap/logs/specific.log
 
   3. Comparison mode:
-     ./analog --ldap -j wsqt9pbpa7yz8gdssw47xzn8hw -c e6frspwx9fgs7y7mmo3o5s5cmh -u "John Doe" -i /path/to/ldap/logs
+     ./analog --ldap -j wsqt9pbpa7yz8gdssw47xzn8hw -c e6frspwx9fgs7y7mmo3o5s5cmh -u "John Doe" -p /path/to/ldap/logs
   `);
 }
 
@@ -94,9 +95,9 @@ function parseFlags(): boolean {
         type: "string",
         short: "u",
       },
-      inFolderPath: {
+      path: {
         type: "string",
-        short: "i",
+        short: "p",
       },
       prefix: {
         type: "string",
@@ -112,7 +113,7 @@ function parseFlags(): boolean {
   flags.jobId = String(values.jobId ?? "");
   flags.compareJobId = String(values.compareJobId ?? "");
   flags.userCN = String(values.user ?? "");
-  flags.inFolderPath = String(values.inFolderPath ?? flags.inFolderPath);
+  flags.path = String(values.path ?? flags.path);
   flags.prefix = String(values.prefix ?? flags.prefix);
   flags.suffix = String(values.suffix ?? flags.suffix);
 

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -1,0 +1,322 @@
+import { parseArgs } from "util";
+import type { ICmd } from "@al/cmd/utils/cmd-runner";
+import fileHelper from "@al/cmd/utils/file-helper";
+
+// --- Logic adapted from .ai/parser2.ts ---
+
+const patterns = {
+  cn: /CN=([^,]+)/,
+  member: /member/,
+};
+
+type GroupMap = Map<string, Set<string>>;
+
+interface PathsResult {
+  paths: string[][]; // All paths ending at the target user
+  cycleGroups: Set<string>; // Unique groups that are part of a cycle
+  groupsLeadingToUser: Set<string>; // Unique groups that eventually lead to the target user
+}
+
+/**
+ * Iterative DFS that finds all paths to a target user, while maintaining:
+ * - A set of groups involved in cycles.
+ * - A set of groups that eventually lead to the user.
+ */
+function createPathsToUser(
+  groupUserCNs: GroupMap,
+  userCN: string
+): PathsResult {
+  const paths: string[][] = [];
+  const cycleGroups = new Set<string>();
+  const groupsLeadingToUser = new Set<string>();
+
+  // Run iterative DFS starting from every group key.
+  for (const group of groupUserCNs.keys()) {
+    // Each stack entry stores the current group and the path taken so far.
+    const stack: { group: string; currentPath: string[] }[] = [
+      { group, currentPath: [group] },
+    ];
+
+    while (stack.length > 0) {
+      const { group: current, currentPath } = stack.pop()!;
+
+      const members = groupUserCNs.get(current);
+      if (!members) continue;
+
+      for (const member of members) {
+        // Check for cycles in the current path.
+        if (currentPath.includes(member)) {
+          cycleGroups.add(member);
+          continue;
+        }
+
+        // If we find the target user, record the valid path.
+        if (member === userCN) {
+          const validPath = [...currentPath, member];
+          paths.push(validPath);
+          // Mark all groups along this path as leading to the target.
+          for (const grp of currentPath) {
+            groupsLeadingToUser.add(grp);
+          }
+        }
+
+        // If the member is also a group, continue DFS.
+        if (groupUserCNs.has(member)) {
+          stack.push({ group: member, currentPath: [...currentPath, member] });
+        }
+      }
+    }
+  }
+
+  return { paths, cycleGroups, groupsLeadingToUser };
+}
+
+// Parses LDAP log lines and extracts group membership information
+function parseLDAPLog(lines: string[], jobId: string): GroupMap {
+  const groupUserCNs = new Map<string, Set<string>>();
+  const responseIdentifier = `Got response worker_name=EnterpriseLdapSync job_id=${jobId}`;
+
+  let currentGroupCN: string | null = null;
+  let isProcessingMembers = false;
+  let foundMemberAttribute = false;
+  let gotResponse = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (!line) continue;
+
+    // Look for the start of a new LDAP response for the specific job ID
+    if (line.includes(responseIdentifier)) {
+      gotResponse = true;
+      currentGroupCN = null;
+      isProcessingMembers = false;
+      foundMemberAttribute = false;
+      continue;
+    }
+
+    if (!gotResponse) continue;
+
+    // Look for Object Name line to get the group CN
+    if (line.startsWith("Object Name:")) {
+      const cnMatch = line.match(patterns.cn);
+      if (cnMatch && cnMatch[1]) {
+        currentGroupCN = cnMatch[1];
+        if (!groupUserCNs.has(currentGroupCN)) {
+          groupUserCNs.set(currentGroupCN, new Set());
+        }
+        isProcessingMembers = false; // Reset processing state for the new object
+        foundMemberAttribute = false;
+      }
+      continue;
+    }
+
+    // Look for the member attribute within the current group context
+    if (line.startsWith("Attribute Name:") && line.match(patterns.member)) {
+      foundMemberAttribute = true;
+      continue;
+    }
+
+    // Process member values if the member attribute was found
+    if (foundMemberAttribute && line.startsWith("Attribute Values:")) {
+      isProcessingMembers = true;
+      continue;
+    }
+
+    if (isProcessingMembers && line.startsWith("Attribute Value:")) {
+      const cnMatch = line.match(patterns.cn);
+      if (cnMatch && currentGroupCN) {
+        const memberCN = cnMatch[1];
+        groupUserCNs.get(currentGroupCN)?.add(memberCN); // Use optional chaining
+      }
+      continue;
+    }
+
+    // If we are processing members but the line is not an Attribute Value,
+    // it means the member section ended. Reset flags.
+    // Also reset gotResponse as we might encounter logs for other jobs.
+    if (isProcessingMembers && !line.startsWith("Attribute Value:")) {
+      isProcessingMembers = false;
+      foundMemberAttribute = false;
+      gotResponse = false; // Reset to look for the next relevant response block
+    }
+  }
+
+  console.log(
+    `Successfully parsed ${groupUserCNs.size} groups from LDAP log for job ${jobId}`
+  );
+  return groupUserCNs;
+}
+
+// --- CLI Command Specific Logic ---
+
+const flags = {
+  jobId: "",
+  userCN: "",
+  inFolderPath: ".",
+  prefix: "ldap",
+  suffix: "log",
+};
+
+function help(): void {
+  console.log(`
+Parses LDAP log files to find all group membership paths for a specific user and job ID.
+
+Usage:
+
+  bun run ./cli/main.js --ldap [arguments]
+
+The arguments are:
+
+  --jobId           (Required) Specifies the job ID to filter the logs by.
+
+  -u, --user        (Required) Specifies the user CN (Common Name) to find paths for.
+
+  -i, --inFolderPath
+                    Specifies the path to the folder containing the LDAP log files.
+                    The folder should only contain log files or nested folders with log files.
+                    Default: . (current directory)
+
+  --prefix
+                    Specifies the prefix for the log files to include.
+                    Default: ldap
+
+  --suffix
+                    Specifies the suffix for the log files to include.
+                    Default: log
+
+Example:
+
+  bun run ./cli/main.js --ldap --jobId "wsqt9pbpa7yz8gdssw47xzn8hw" -u "John Doe" -i "/path/to/ldap/logs"
+  `);
+}
+
+async function run(): Promise<void> {
+  parseFlags();
+
+  if (!flags.jobId) {
+    console.error("Error: --jobId flag is required.");
+    help();
+    process.exit(1);
+  }
+  if (!flags.userCN) {
+    console.error("Error: --user (-u) flag is required.");
+    help();
+    process.exit(1);
+  }
+
+  await processLogs();
+}
+
+function parseFlags() {
+  const { values } = parseArgs({
+    args: Bun.argv,
+    options: {
+      ldap: {
+        // Consumed by main.ts
+        type: "boolean",
+        short: "l",
+      },
+      jobId: {
+        type: "string",
+      },
+      user: {
+        type: "string",
+        short: "u",
+      },
+      inFolderPath: {
+        type: "string",
+        short: "i",
+        default: flags.inFolderPath,
+      },
+      prefix: {
+        type: "string",
+        default: flags.prefix,
+      },
+      suffix: {
+        type: "string",
+        default: flags.suffix,
+      },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  flags.inFolderPath = String(values.inFolderPath ?? flags.inFolderPath);
+  flags.prefix = String(values.prefix ?? flags.prefix);
+  flags.suffix = String(values.suffix ?? flags.suffix);
+  flags.jobId = String(values.jobId ?? "");
+  flags.userCN = String(values.user ?? "");
+}
+
+async function processLogs() {
+  const filePaths = await fileHelper.getFilesRecursively(
+    flags.inFolderPath,
+    flags.prefix,
+    flags.suffix
+  );
+
+  if (filePaths.length === 0) {
+    console.log(
+      `No files found matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}". Exiting.`
+    );
+    process.exit(0);
+  }
+
+  console.log(
+    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
+  );
+
+  console.log("========= Reading Files =========");
+  let allLines: string[] = [];
+  for (const filePath of filePaths) {
+    console.log(`Reading: ${filePath}`);
+    try {
+      const content = await Bun.file(filePath).text();
+      allLines = allLines.concat(content.split(/\r?\n/));
+    } catch (err) {
+      console.error(`Error reading file ${filePath}:`, err);
+    }
+  }
+  console.log(`Read total ${allLines.length} lines.`);
+  console.log("========= Finished Reading Files =========");
+
+  console.log("========= Parsing Logs =========");
+  const groupUserCNs = parseLDAPLog(allLines, flags.jobId);
+  console.log("========= Finished Parsing Logs =========");
+
+  if (groupUserCNs.size === 0) {
+    console.log(`No group information found for job ID "${flags.jobId}".`);
+    process.exit(0);
+  }
+
+  console.log(`========= Finding Paths for User: ${flags.userCN} =========`);
+  const { paths, cycleGroups, groupsLeadingToUser } = createPathsToUser(
+    groupUserCNs,
+    flags.userCN
+  );
+
+  if (paths.length === 0) {
+    console.log(
+      `User "${flags.userCN}" not found in any group memberships for job ID "${flags.jobId}".`
+    );
+  } else {
+    console.log(`Found ${paths.length} paths to user ${flags.userCN}:`);
+    console.log(paths.map((path) => path.join(" -> ")).join("\n"));
+    console.log("\n---");
+    console.log(`Found ${cycleGroups.size} cyclic groups involved in paths:`);
+    console.log(Array.from(cycleGroups).join(", "));
+    console.log("\n---");
+    console.log(
+      `Found ${groupsLeadingToUser.size} unique groups leading to user ${flags.userCN}:`
+    );
+    console.log(Array.from(groupsLeadingToUser).join(", "));
+  }
+  console.log(`========= Finished Finding Paths =========`);
+}
+
+const ldapCmd: ICmd = {
+  help,
+  run,
+};
+
+export default ldapCmd;

--- a/cmd/src/commands/ldap/index.ts
+++ b/cmd/src/commands/ldap/index.ts
@@ -1,27 +1,11 @@
 import { parseArgs } from "util";
 import type { ICmd } from "@al/cmd/utils/cmd-runner";
-import fileHelper from "@al/cmd/utils/file-helper";
+import { defaultFlags } from "./types";
+import type { Flags } from "./types";
+import handleUserSearch from "./search-user";
+import handleGroupPaths from "./group-paths";
 
-const flags = {
-  jobId: "",
-  userCN: "",
-  inFolderPath: ".",
-  prefix: "ldap",
-  suffix: "log",
-};
-
-const patterns = {
-  cn: /CN=([^,]+)/,
-  member: /member/,
-};
-
-type GroupMap = Map<string, Set<string>>;
-
-interface PathsResult {
-  paths: string[][]; // All paths ending at the target user
-  cycleGroups: Set<string>; // Unique groups that are part of a cycle
-  groupsLeadingToUser: Set<string>; // Unique groups that eventually lead to the target user
-}
+const flags: Flags = { ...defaultFlags };
 
 function help(): void {
   console.log(`
@@ -58,24 +42,8 @@ Example:
   `);
 }
 
-async function run(): Promise<void> {
-  parseFlags();
-
-  if (!flags.jobId) {
-    console.error("Error: --jobId flag is required.");
-    help();
-    process.exit(1);
-  }
-  if (!flags.userCN) {
-    console.error("Error: --user (-u) flag is required.");
-    help();
-    process.exit(1);
-  }
-
-  await processLogs();
-}
-
-function parseFlags() {
+// returns true if interactive mode, false if non-interactive mode
+function parseFlags(): boolean {
   const { values } = parseArgs({
     args: Bun.argv,
     options: {
@@ -111,265 +79,39 @@ function parseFlags() {
   flags.inFolderPath = String(values.inFolderPath ?? flags.inFolderPath);
   flags.prefix = String(values.prefix ?? flags.prefix);
   flags.suffix = String(values.suffix ?? flags.suffix);
+
+  const interactive = !flags.jobId && !flags.userCN;
+
+  if (interactive) {
+    console.log("No flags provided, running in interactive mode...\n");
+    return true;
+  }
+
+  // non-interactive mode
+  if (!flags.jobId) {
+    console.error("Error: --jobId flag is required.");
+    help();
+    process.exit(1);
+  }
+  if (!flags.userCN) {
+    console.error("Error: --user (-u) flag is required.");
+    help();
+    process.exit(1);
+  }
+
+  return false;
 }
 
-async function processLogs() {
-  const filePaths = await fileHelper.getFilesRecursively(
-    flags.inFolderPath,
-    flags.prefix,
-    flags.suffix
-  );
-
-  if (filePaths.length === 0) {
-    console.log(
-      `No files found matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}". Exiting.`
-    );
-    process.exit(0);
+async function run(): Promise<void> {
+  const interactive = parseFlags();
+  if (interactive) {
+    console.log("No flags provided, running in interactive mode...\n");
+    await handleUserSearch(flags);
+    return;
   }
 
-  console.log(
-    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
-  );
-
-  let allLines: string[] = await getSortedLines(filePaths);
-
-  console.log("\n========= Parsing Logs =========");
-  const groupUserCNs = parseLDAPLog(allLines, flags.jobId);
-  console.log("========= Finished Parsing Logs =========");
-
-  if (groupUserCNs.size === 0) {
-    console.log(
-      `No group information found for job ID "${flags.jobId}" in the processed files.`
-    );
-    process.exit(0);
-  }
-
-  console.log(`\n========= Finding Paths for User: ${flags.userCN} =========`);
-  const { paths, cycleGroups, groupsLeadingToUser } = createPathsToUser(
-    groupUserCNs,
-    flags.userCN
-  );
-
-  if (paths.length === 0) {
-    console.log(
-      `User "${flags.userCN}" not found in any group memberships for job ID "${flags.jobId}" in the processed files.`
-    );
-  } else {
-    const sortedPaths = paths
-      .map((path) => path.join(" -> "))
-      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
-
-    console.log(`Found ${sortedPaths.length} paths to user ${flags.userCN}:`);
-    console.log(sortedPaths.join("\n"));
-    console.log("\n---");
-    console.log(`Found ${cycleGroups.size} cyclic groups involved in paths:`);
-    console.log(Array.from(cycleGroups).join(", "));
-    console.log("\n---");
-    console.log(
-      `Found ${groupsLeadingToUser.size} unique groups leading to user ${flags.userCN}:`
-    );
-    console.log(Array.from(groupsLeadingToUser).join(", "));
-  }
-  console.log(`========= Finished Finding Paths =========`);
-}
-
-async function getSortedLines(filePaths: string[]): Promise<string[]> {
-  let allLines: string[] = [];
-
-  console.log("\n========= Reading Files & Finding Timestamps =========");
-
-  const fileData: {
-    filePath: string;
-    lines: string[];
-    firstTimestamp: string | null;
-  }[] = [];
-  for (const filePath of filePaths) {
-    console.log(`Reading: ${filePath}`);
-    try {
-      const content = await Bun.file(filePath).text();
-      const lines = content.split(/\r?\n/); // Keep escaped regex
-      const firstTimestamp = findFirstTimestamp(lines);
-      if (firstTimestamp) {
-        fileData.push({ filePath, lines, firstTimestamp });
-        console.log(`  Found start timestamp: ${firstTimestamp}`);
-      } else {
-        console.log(
-          `  Warning: No 'LDAPTrace [timestamp]' line found in ${filePath}. Skipping file.`
-        );
-      }
-    } catch (err) {
-      console.error(`Error reading or processing file ${filePath}:`, err);
-    }
-  }
-
-  if (fileData.length === 0) {
-    console.log("No valid files with timestamps found to process. Exiting.");
-    process.exit(0);
-  }
-
-  console.log("========= Sorting Files by Timestamp =========");
-  fileData.sort((a, b) => a.firstTimestamp!.localeCompare(b.firstTimestamp!));
-
-  console.log("Sorted file order:");
-  fileData.forEach((f) =>
-    console.log(`  - ${f.filePath} (${f.firstTimestamp})`)
-  );
-
-  console.log("========= Concatenating Sorted Files =========");
-  for (const data of fileData) {
-    allLines = allLines.concat(data.lines);
-  }
-  console.log(
-    `Concatenated total ${allLines.length} lines from ${fileData.length} sorted files.`
-  );
-  console.log("========= Finished Reading & Sorting Files =========");
-
-  return allLines;
-}
-
-/**
- * Iterative DFS that finds all paths to a target user, while maintaining:
- * - A set of groups involved in cycles.
- * - A set of groups that eventually lead to the user.
- */
-function createPathsToUser(
-  groupUserCNs: GroupMap,
-  userCN: string
-): PathsResult {
-  const paths: string[][] = [];
-  const cycleGroups = new Set<string>();
-  const groupsLeadingToUser = new Set<string>();
-
-  // Run iterative DFS starting from every group key.
-  for (const group of groupUserCNs.keys()) {
-    // Each stack entry stores the current group and the path taken so far.
-    const stack: { group: string; currentPath: string[] }[] = [
-      { group, currentPath: [group] },
-    ];
-
-    while (stack.length > 0) {
-      const { group: current, currentPath } = stack.pop()!;
-
-      const members = groupUserCNs.get(current);
-      if (!members) continue;
-
-      for (const member of members) {
-        // Check for cycles in the current path.
-        if (currentPath.includes(member)) {
-          cycleGroups.add(member);
-          continue;
-        }
-
-        // If we find the target user, record the valid path.
-        if (member === userCN) {
-          const validPath = [...currentPath, member];
-          paths.push(validPath);
-          // Mark all groups along this path as leading to the target.
-          for (const grp of currentPath) {
-            groupsLeadingToUser.add(grp);
-          }
-        }
-
-        // If the member is also a group, continue DFS.
-        if (groupUserCNs.has(member)) {
-          stack.push({ group: member, currentPath: [...currentPath, member] });
-        }
-      }
-    }
-  }
-
-  return { paths, cycleGroups, groupsLeadingToUser };
-}
-
-// Parses LDAP log lines and extracts group membership information
-function parseLDAPLog(lines: string[], jobId: string): GroupMap {
-  const groupUserCNs: GroupMap = new Map<string, Set<string>>();
-  const responseIdentifier = `Got response worker_name=EnterpriseLdapSync job_id=${jobId}`;
-
-  let currentGroupCN: string | null = null;
-  let isProcessingMembers = false;
-  let foundMemberAttribute = false;
-  let gotResponse = false;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i].trim();
-    if (!line) continue;
-
-    // Look for the start of a new LDAP response for the specific job ID
-    if (line.includes(responseIdentifier)) {
-      gotResponse = true;
-      currentGroupCN = null;
-      isProcessingMembers = false;
-      foundMemberAttribute = false;
-      continue;
-    }
-
-    if (!gotResponse) continue;
-
-    // Look for Object Name line to get the group CN
-    if (line.startsWith("Object Name:")) {
-      const cnMatch = line.match(patterns.cn);
-      if (cnMatch && cnMatch[1]) {
-        currentGroupCN = cnMatch[1];
-        if (!groupUserCNs.has(currentGroupCN)) {
-          groupUserCNs.set(currentGroupCN, new Set());
-        }
-        isProcessingMembers = false; // Reset processing state for the new object
-        foundMemberAttribute = false;
-      }
-      continue;
-    }
-
-    // Look for the member attribute within the current group context
-    if (line.startsWith("Attribute Name:") && line.match(patterns.member)) {
-      foundMemberAttribute = true;
-      continue;
-    }
-
-    // Process member values if the member attribute was found
-    if (foundMemberAttribute && line.startsWith("Attribute Values:")) {
-      isProcessingMembers = true;
-      continue;
-    }
-
-    if (isProcessingMembers && line.startsWith("Attribute Value:")) {
-      const cnMatch = line.match(patterns.cn);
-      if (cnMatch && currentGroupCN) {
-        const memberCN = cnMatch[1];
-        groupUserCNs.get(currentGroupCN)?.add(memberCN); // Use optional chaining
-      }
-      continue;
-    }
-
-    // If we are processing members but the line is not an Attribute Value,
-    // it means the member section ended. Reset flags.
-    // Also reset gotResponse as we might encounter logs for other jobs.
-    if (isProcessingMembers && !line.startsWith("Attribute Value:")) {
-      isProcessingMembers = false;
-      foundMemberAttribute = false;
-      gotResponse = false; // Reset to look for the next relevant response block
-    }
-  }
-
-  console.log(
-    `Successfully parsed ${groupUserCNs.size} groups from LDAP log for job ${jobId}`
-  );
-  return groupUserCNs;
-}
-
-// Helper function to find the first timestamp in the specific format
-function findFirstTimestamp(lines: string[]): string | null {
-  // Regex to match "LDAPTrace [timestamp]" and capture the timestamp part
-  // Example: LDAPTrace [2025-03-15 07:28:00.045 +11:00] some message
-  const timestampRegex =
-    /^(?:LDAPTrace|LDAPDebug)\s+\[(\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}\.\d{3}\s+[+-]\d{2}:\d{2})\]/;
-  for (const line of lines) {
-    const match = line.match(timestampRegex);
-    if (match && match[1]) {
-      return match[1]; // Return the captured timestamp string
-    }
-  }
-  return null; // Return null if no matching line is found
+  // non-interactive mode
+  handleGroupPaths(flags);
 }
 
 const ldapCmd: ICmd = {

--- a/cmd/src/commands/ldap/search-user.ts
+++ b/cmd/src/commands/ldap/search-user.ts
@@ -1,0 +1,244 @@
+import { select, confirm, input } from "@inquirer/prompts";
+import type { Flags, FileLines } from "./types";
+import { getSortedLines } from "./helper";
+
+const patterns = {
+  cn: /CN=([^,]+)/,
+  lastDoubleQuote: /"([^"]+)"/,
+};
+
+interface UserAttribute {
+  key: string;
+  value: string;
+}
+
+export interface SearchConfig {
+  responseType?: "login" | "job" | "any";
+  jobId?: string;
+  userCN?: string;
+  attributes: UserAttribute[];
+}
+
+export interface SearchResult {
+  filePath: string;
+  lineNumber: number;
+  attributes: Record<string, string>;
+}
+
+async function handleUserSearch(flags: Flags): Promise<void> {
+  let config: SearchConfig;
+  try {
+    config = await gatherSearchConfig();
+  } catch (err) {
+    if (err instanceof Error && err.name === "ExitPromptError") {
+      console.log("Exiting...");
+      return;
+    }
+    throw err;
+  }
+
+  const fileLines: FileLines[] = await getSortedLines(flags);
+
+  console.log("\n========= Searching for User =========");
+  const result = parseLogs(config, fileLines);
+  printResults(result);
+}
+
+export function printResults(result: SearchResult | null) {
+  if (result) {
+    console.log(
+      `\nFound matching user at ${result.filePath}:${result.lineNumber}`
+    );
+    console.log("\nUser attributes:");
+    for (const [key, value] of Object.entries(result.attributes)) {
+      console.log(`- ${key}: ${value}`);
+    }
+  } else {
+    console.log("\nNo matching user found.");
+  }
+}
+
+async function gatherSearchConfig(): Promise<SearchConfig> {
+  const config: SearchConfig = {
+    attributes: [],
+  };
+
+  config.responseType = (await select({
+    message: "Choose response block type:",
+    choices: [
+      {
+        value: "job",
+        name: "Job block (Got response worker_name=EnterpriseLdapSync)",
+      },
+      { value: "login", name: "Login block (Got response path=/login)" },
+      { value: "any", name: "Any" },
+    ],
+  })) as "login" | "job" | "any";
+
+  if (config.responseType === "job") {
+    const specificJob = await confirm({
+      message: "Do you want to search for a specific job ID?",
+    });
+
+    if (specificJob) {
+      config.jobId = await input({
+        message: "Enter the job ID:",
+      });
+    }
+  }
+
+  // Must have either user CN or at least one attribute
+  const searchType = (await select({
+    message: "Choose search type:",
+    choices: [
+      { value: "userCN", name: "User CN" },
+      { value: "attributes", name: "Attributes" },
+    ],
+  })) as "userCN" | "attributes";
+
+  if (searchType === "userCN") {
+    config.userCN = await input({
+      message: "Enter the user CN:",
+      required: true,
+    });
+  } else {
+    let addMore = true;
+    while (addMore) {
+      const key = await input({
+        message: "Enter attribute key (e.g., mail, givenName):",
+        required: true,
+      });
+
+      const value = await input({
+        message: `Enter value for ${key}:`,
+        required: true,
+      });
+
+      config.attributes.push({ key, value });
+
+      addMore = await confirm({
+        message: "Do you want to add another attribute?",
+      });
+    }
+  }
+
+  return config;
+}
+
+export function parseLogs(
+  config: SearchConfig,
+  fileLines: FileLines[]
+): SearchResult | null {
+  let result: SearchResult | null = null;
+
+  const loginResponseIdentifier = "Got response path=/login";
+  let jobResponseIdentifier =
+    "Got response worker_name=EnterpriseLdapSync job_id=";
+
+  if (config.jobId) {
+    jobResponseIdentifier += config.jobId;
+  }
+
+  let gotResponse = false;
+  let foundUser = false;
+  let reachedTop = false;
+  let attributeName: string | undefined;
+
+  const resetFlags = () => {
+    gotResponse = false;
+    foundUser = false;
+    reachedTop = false;
+    attributeName = undefined;
+  };
+
+  for (const fileLine of fileLines) {
+    for (let i = 0; i < fileLine.lines.length; i++) {
+      let line = fileLine.lines[i].trim();
+      if (!line) continue;
+
+      // Check if line matches response block type
+      if (
+        (config.responseType === "login" &&
+          line.includes(loginResponseIdentifier)) ||
+        (config.responseType === "job" &&
+          line.includes(jobResponseIdentifier)) ||
+        (config.responseType === "any" &&
+          (line.includes(loginResponseIdentifier) ||
+            line.includes(jobResponseIdentifier)))
+      ) {
+        resetFlags();
+        gotResponse = true;
+        continue;
+      }
+
+      if (!gotResponse) continue;
+
+      if (config.userCN) {
+        // Object Name: (Universal, Primitive, Octet String) Len=82 "CN=Tony Stark,OU=Avengers,DC=Marvel,DC=com"
+        if (line.startsWith("Object Name:")) {
+          const cnMatch = line.match(patterns.cn);
+          if (cnMatch && cnMatch[1]) {
+            // If the CN does not match, skip the whole response block
+            if (!(cnMatch[1] === config.userCN)) {
+              resetFlags();
+              continue;
+            }
+
+            foundUser = true;
+
+            result = {
+              filePath: fileLine.filePath,
+              lineNumber: i + 1,
+              attributes: {},
+            };
+          }
+          continue;
+        }
+      }
+
+      if (foundUser && !reachedTop) {
+        // go to the top till "Object Name:"
+        while (!line.startsWith("Object Name:")) {
+          i--;
+          line = fileLine.lines[i].trim();
+        }
+
+        reachedTop = true;
+        continue;
+      }
+
+      if (reachedTop) {
+        // Attribute Name: (Universal, Primitive, Octet String) Len=4 "mail"
+        if (line.startsWith("Attribute Name:")) {
+          attributeName = line.match(patterns.lastDoubleQuote)?.[1];
+          if (attributeName) {
+            result!.attributes[attributeName] = "";
+          }
+          continue;
+        }
+
+        if (attributeName) {
+          // Attribute Value: (Universal, Primitive, Octet String) Len=23 "tony.stark@marvel.com"
+          if (line.startsWith("Attribute Value:")) {
+            const attributeValue = line.match(patterns.lastDoubleQuote)?.[1];
+            if (attributeValue) {
+              result!.attributes[attributeName] = attributeValue;
+            }
+            attributeName = undefined;
+            continue;
+          }
+        }
+
+        // If not starting with Attribute, then we are no longer in the attributes block
+        if (!line.startsWith("Attribute")) {
+          // Found first occurrence of the user and collected all attributes
+          return result;
+        }
+      }
+    }
+  }
+
+  return result;
+}
+
+export default handleUserSearch;

--- a/cmd/src/commands/ldap/search-user.ts
+++ b/cmd/src/commands/ldap/search-user.ts
@@ -96,11 +96,11 @@ async function gatherSearchConfig(): Promise<SearchConfig> {
       config.timeRange = {
         start: await input({
           message: "Enter the start time (inclusive):",
-          required: true,
+          default: "0",
         }),
         end: await input({
           message: "Enter the end time (exclusive):",
-          required: true,
+          default: "z",
         }),
       };
     }

--- a/cmd/src/commands/ldap/types.ts
+++ b/cmd/src/commands/ldap/types.ts
@@ -5,6 +5,7 @@ export interface FileLines {
 
 export interface Flags {
   jobId: string;
+  compareJobId: string;
   userCN: string;
   inFolderPath: string;
   prefix: string;
@@ -13,6 +14,7 @@ export interface Flags {
 
 export const defaultFlags: Flags = {
   jobId: "",
+  compareJobId: "",
   userCN: "",
   inFolderPath: ".",
   prefix: "ldap",

--- a/cmd/src/commands/ldap/types.ts
+++ b/cmd/src/commands/ldap/types.ts
@@ -1,0 +1,20 @@
+export interface FileLines {
+  filePath: string;
+  lines: string[];
+}
+
+export interface Flags {
+  jobId: string;
+  userCN: string;
+  inFolderPath: string;
+  prefix: string;
+  suffix: string;
+}
+
+export const defaultFlags: Flags = {
+  jobId: "",
+  userCN: "",
+  inFolderPath: ".",
+  prefix: "ldap",
+  suffix: "log",
+};

--- a/cmd/src/commands/ldap/types.ts
+++ b/cmd/src/commands/ldap/types.ts
@@ -7,7 +7,7 @@ export interface Flags {
   jobId: string;
   compareJobId: string;
   userCN: string;
-  inFolderPath: string;
+  path: string;
   prefix: string;
   suffix: string;
 }
@@ -16,7 +16,7 @@ export const defaultFlags: Flags = {
   jobId: "",
   compareJobId: "",
   userCN: "",
-  inFolderPath: ".",
+  path: ".",
   prefix: "ldap",
   suffix: "log",
 };

--- a/cmd/src/commands/merger/index.ts
+++ b/cmd/src/commands/merger/index.ts
@@ -30,7 +30,7 @@ Caution:  Passing a big time range could lead to keeping millions of log lines i
 
 Usage:
 
-  bun run ./cli/main.js --merger [arguments]
+  ./analog --merger [arguments]
 
 The arguments are:
   
@@ -62,7 +62,7 @@ The arguments are:
 
 Example: 
   
-  bun run ./cli/main.js -m -x "2024-01-25 19:00:00.000 +00:00" -y "2024-01-25 19:05:00.000 +00:00" -i "/path/to/logs/folder" -o "/path/to/filtered/log/filename.log" --prefix "app-" --suffix "txt"
+  ./analog -m -x "2024-01-25 19:00:00.000 +00:00" -y "2024-01-25 19:05:00.000 +00:00" -i "/path/to/logs/folder" -o "/path/to/filtered/log/filename.log" --prefix "app-" --suffix "txt"
     `);
 }
 

--- a/cmd/src/commands/merger/index.ts
+++ b/cmd/src/commands/merger/index.ts
@@ -11,7 +11,7 @@ let workerURL = new URL("worker.ts", import.meta.url);
 const flags = {
   minTime: "0",
   maxTime: "z",
-  inFolderPath: ".",
+  path: ".",
   outFileName: "./merged-logs.log",
   prefix: "mattermost",
   suffix: "log",
@@ -42,9 +42,10 @@ The arguments are:
         Filters out logs with timestamps equal or later than the specified maximum time(exclusive).
         Default: maxTime of all the logs in the folder.
   
-  -i, --inFolderPath      
-        Specifies the path to the folder containing the log files. 
-        The folder should only contain log files or nested folders with log files.
+  -p, --path      
+        Specifies the path to either a single log file or a folder containing log files.
+        If a folder is provided, it traverses all the files in the folder and its subfolders.
+        If a file is provided, then prefix and suffix flags are ignored.
         Default: . (current directory)
   
   -o, --outFileName
@@ -62,7 +63,7 @@ The arguments are:
 
 Example: 
   
-  ./analog -m -x "2024-01-25 19:00:00.000 +00:00" -y "2024-01-25 19:05:00.000 +00:00" -i "/path/to/logs/folder" -o "/path/to/filtered/log/filename.log" --prefix "app-" --suffix "txt"
+  ./analog -m -x "2024-01-25 19:00:00.000 +00:00" -y "2024-01-25 19:05:00.000 +00:00" -p "/path/to/logs/folder" -o "/path/to/filtered/log/filename.log" --prefix "app-" --suffix "txt"
     `);
 }
 
@@ -96,10 +97,10 @@ function parseFlags() {
         short: "y",
         default: flags.maxTime,
       },
-      inFolderPath: {
+      path: {
         type: "string",
-        short: "i",
-        default: flags.inFolderPath,
+        short: "p",
+        default: flags.path,
       },
       outFileName: {
         type: "string",
@@ -119,7 +120,7 @@ function parseFlags() {
     allowPositionals: true,
   });
 
-  flags.inFolderPath = String(values.inFolderPath);
+  flags.path = String(values.path);
   flags.outFileName = String(values.outFileName);
   flags.minTime = String(values.minTime);
   flags.maxTime = String(values.maxTime);
@@ -128,14 +129,14 @@ function parseFlags() {
 }
 
 async function processLogs() {
-  const filePaths = await fileHelper.getFilesRecursively(
-    flags.inFolderPath,
+  const filePaths = await fileHelper.getFiles(
+    flags.path,
     flags.prefix,
     flags.suffix
   );
 
   console.log(
-    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
+    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.path}"`
   );
 
   console.log("=========Begin Read Files=========");

--- a/cmd/src/commands/summary/index.ts
+++ b/cmd/src/commands/summary/index.ts
@@ -50,7 +50,7 @@ const stats: IStats = {
 };
 
 const flags = {
-  inFolderPath: ".",
+  path: ".",
   topLogsCount: 30,
   prefix: "mattermost",
   suffix: "log",
@@ -66,9 +66,10 @@ Usage:
 
 The arguments are:
   
-  -i, --inFolderPath
-        Specifies the path to the folder containing the log files. 
-        The folder should only contain log files or nested folders with log files.
+  -p, --path
+        Specifies the path to either a single log file or a folder containing log files.
+        If a folder is provided, it traverses all the files in the folder and its subfolders.
+        If a file is provided, then prefix and suffix flags are ignored.
         Default: . (current directory)
   
   -t, --top             
@@ -85,7 +86,7 @@ The arguments are:
 
 Example: 
   
-  ./analog -s -i "/path/to/logs/folder" --prefix "debug-" --suffix "txt"
+  ./analog -s -p "/path/to/logs/folder" --prefix "debug-" --suffix "txt"
     `);
 }
 
@@ -109,10 +110,10 @@ function parseFlags() {
         type: "boolean",
         short: "s",
       },
-      inFolderPath: {
+      path: {
         type: "string",
-        short: "i",
-        default: flags.inFolderPath,
+        short: "p",
+        default: flags.path,
       },
       top: {
         type: "string",
@@ -132,21 +133,21 @@ function parseFlags() {
     allowPositionals: true,
   });
 
-  flags.inFolderPath = String(values.inFolderPath);
+  flags.path = String(values.path);
   flags.topLogsCount = Number(values.top) || flags.topLogsCount;
   flags.prefix = String(values.prefix);
   flags.suffix = String(values.suffix);
 }
 
 async function processLogs() {
-  const filePaths = await fileHelper.getFilesRecursively(
-    flags.inFolderPath,
+  const filePaths = await fileHelper.getFiles(
+    flags.path,
     flags.prefix,
     flags.suffix
   );
 
   console.log(
-    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.inFolderPath}"`
+    `Found ${filePaths.length} files matching prefix "${flags.prefix}" and suffix "${flags.suffix}" in "${flags.path}"`
   );
 
   console.log("=========Begin Read Files=========");

--- a/cmd/src/commands/summary/index.ts
+++ b/cmd/src/commands/summary/index.ts
@@ -62,7 +62,7 @@ Summary provides a summary view of all the log files.
 
 Usage:
 
-  bun run ./cli/main.js --summary [arguments]
+  ./analog --summary [arguments]
 
 The arguments are:
   
@@ -85,7 +85,7 @@ The arguments are:
 
 Example: 
   
-  bun run ./cli/main.js -s -i "/path/to/logs/folder" --prefix "debug-" --suffix "txt"
+  ./analog -s -i "/path/to/logs/folder" --prefix "debug-" --suffix "txt"
     `);
 }
 
@@ -128,7 +128,7 @@ function parseFlags() {
         default: flags.suffix,
       },
     },
-    strict: false,
+    strict: true,
     allowPositionals: true,
   });
 

--- a/cmd/src/commands/web/index.ts
+++ b/cmd/src/commands/web/index.ts
@@ -19,7 +19,7 @@ Starts a web server to serve the Analog UI.
 
 Usage: 
 
-  bun run ./cmd/src/main.ts --web [arguments]
+  ./analog --web [arguments]
 
 The arguments are:
 
@@ -29,7 +29,7 @@ The arguments are:
 
 Example:
 
-  bun run ./cmd/src/main.ts --web --port 8080
+  ./analog --web --port 8080
   `);
 }
 

--- a/cmd/src/main.ts
+++ b/cmd/src/main.ts
@@ -117,9 +117,10 @@ e.g. ./analog --help --merger
 
 Example:
 
-  ./analog --ldap --jobId <jobId> -u "User Name" -i ./ldap_logs
+  ./analog --ldap --jobId <jobId> -u "User Name" -p ./ldap_logs
+  ./analog --merger -p /path/to/logs/folder --outFileName merged.log
+  ./analog --summary -p /path/to/specific.log -t 50
   ./analog --web --port 8080
-  ./analog --merger --inFolderPath ../../logs --outFileName merged.log
 
 Caution: Processing multiple files will need at least twice the space as the logs files size.
           For example, if you are analyzing 4GB of logs make sure you have 8GB of *free* RAM left for smoother processing.

--- a/cmd/src/main.ts
+++ b/cmd/src/main.ts
@@ -101,7 +101,7 @@ Usage:
 The commands are:
 
   -l, --ldap
-        Parses LDAP log files to find group membership paths for a specific user.
+        Parses LDAP log files to find all group membership paths for a specific user and job ID, or search for users based on various criteria.
 
   -m, --merger
         merges all files from a given folder within a time range and generate a single time-sorted log file with unique log entries.
@@ -121,7 +121,7 @@ Example:
   ./analog --web --port 8080
   ./analog --merger --inFolderPath ../../logs --outFileName merged.log
 
-Caution (for merger/summary): Processing multiple files will need at least twice the space as the logs files size.
+Caution: Processing multiple files will need at least twice the space as the logs files size.
           For example, if you are analyzing 4GB of logs make sure you have 8GB of *free* RAM left for smoother processing.
 
 A few utility commands can also be found here - https://github.com/vish9812/analog?tab=readme-ov-file#utility-commands.

--- a/cmd/src/main.ts
+++ b/cmd/src/main.ts
@@ -4,6 +4,7 @@ import figlet from "figlet";
 import merger from "./commands/merger";
 import summary from "./commands/summary";
 import web from "./commands/web";
+import ldapCmd from "./commands/ldap";
 import type { ICmd } from "./utils/cmd-runner";
 
 // Handle Ctrl-C
@@ -34,6 +35,10 @@ const { values: flags } = parseArgs({
       type: "boolean",
       short: "w",
     },
+    ldap: {
+      type: "boolean",
+      short: "l",
+    },
   },
   strict: false,
   allowPositionals: true,
@@ -49,6 +54,8 @@ if (typeof flags.merger === "boolean" && flags.merger) {
   cmd = summary;
 } else if (typeof flags.web === "boolean" && flags.web) {
   cmd = web;
+} else if (typeof flags.ldap === "boolean" && flags.ldap) {
+  cmd = ldapCmd;
 } else {
   if (isHelp) {
     help();
@@ -70,11 +77,11 @@ if (isHelp && cmd) {
 function help() {
   console.log(figlet.textSync(`ANALOG`));
   console.log(`
-                         .="=.
+                         .=".=
                       _/.-.-.\\_     _
                      ( ( o o ) )    ))
-                      |/  "  \\|    //
-      .-------.        \\'---'/    //
+                      |/  "  \||    //
+      .-------.        \\\'---'/    //
      _|~~ ~~  |_       /'"""'\\\\  ((
    =(_|_______|_)=    / /_,_\\ \\\\  \\\\
      |:::::::::|      \\_\\\\_'__/ \\  ))
@@ -93,6 +100,9 @@ Usage:
 
 The commands are:
 
+  -l, --ldap
+        Parses LDAP log files to find group membership paths for a specific user.
+
   -m, --merger
         merges all files from a given folder within a time range and generate a single time-sorted log file with unique log entries.
 
@@ -107,6 +117,7 @@ e.g. bun run ./cmd/src/main.ts --help --merger
 
 Example:
 
+  bun run ./cmd/src/main.ts --ldap --jobId <jobId> -u "User Name" -i ./ldap_logs
   bun run ./cmd/src/main.ts --web --port 8080
   bun run ./cmd/src/main.ts --merger --inFolderPath ../../logs --outFileName merged.log
 

--- a/cmd/src/main.ts
+++ b/cmd/src/main.ts
@@ -96,7 +96,7 @@ Run analog as cli for analyzing multiple log files or serving the UI.
 
 Usage:
 
-  bun run ./cmd/src/main.ts <command> [arguments]
+  ./analog <command> [arguments]
 
 The commands are:
 
@@ -112,14 +112,14 @@ The commands are:
   -w, --web
         starts a web server to serve the Analog UI from the 'dist' folder.
 
-Use "bun run ./cmd/src/main.ts --help --<command>" for more information about a command.
-e.g. bun run ./cmd/src/main.ts --help --merger
+Use "./analog --help --<command>" for more information about a command.
+e.g. ./analog --help --merger
 
 Example:
 
-  bun run ./cmd/src/main.ts --ldap --jobId <jobId> -u "User Name" -i ./ldap_logs
-  bun run ./cmd/src/main.ts --web --port 8080
-  bun run ./cmd/src/main.ts --merger --inFolderPath ../../logs --outFileName merged.log
+  ./analog --ldap --jobId <jobId> -u "User Name" -i ./ldap_logs
+  ./analog --web --port 8080
+  ./analog --merger --inFolderPath ../../logs --outFileName merged.log
 
 Caution (for merger/summary): Processing multiple files will need at least twice the space as the logs files size.
           For example, if you are analyzing 4GB of logs make sure you have 8GB of *free* RAM left for smoother processing.

--- a/cmd/src/utils/file-helper/index.ts
+++ b/cmd/src/utils/file-helper/index.ts
@@ -1,11 +1,19 @@
-import { readdir } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import * as path from "node:path";
 
-async function getFilesRecursively(
-  folderPath: string,
+async function getFiles(
+  targetPath: string,
   prefix: string,
   suffix: string
 ): Promise<string[]> {
+  const stats = await stat(targetPath);
+
+  // If it's a file, return it directly
+  if (stats.isFile()) {
+    return [targetPath];
+  }
+
+  // If it's a directory, search recursively with prefix/suffix filtering
   const fileList: string[] = [];
 
   async function readDirectory(currentPath: string) {
@@ -26,13 +34,12 @@ async function getFilesRecursively(
     }
   }
 
-  await readDirectory(folderPath);
-
+  await readDirectory(targetPath);
   return fileList;
 }
 
 const fileHelper = {
-  getFilesRecursively,
+  getFiles,
 };
 
 export default fileHelper;


### PR DESCRIPTION
Added a new LDAP command to analyze LDAP log files with three distinct operational modes:

1. Interactive Mode (-i):
   - Enables dynamic searching of user attributes in login/job response blocks
   - Supports filtering by job ID and searching by user attributes (CN, email, name)
   - Allows specifying time ranges for targeted searches

2. Non-interactive Mode (--jobId + --user):
   - Finds and traces group membership paths for specific users
   - Requires job ID and user CN for focused analysis

3. Comparison Mode (--jobId + --compareJobId + --user):
   - Compares LDAP data between two different jobs
   - Useful for tracking changes in user permissions/group memberships

Common Features:
- Flexible log file handling with support for single file or directory processing
- Configurable file filtering using prefix/suffix patterns